### PR TITLE
fix: lock sdk with installed auth-js major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   - Removed `isPending` from `AuthState`
   - Default value for `originalUri` is null
 
+# 4.0.1
+
+### Bug Fixes
+
+- [#60](https://github.com/okta/okta-vue/pull/60) Locks the SDK with installed okta-auth-js major version
+
 # 4.0.0
 
 ### Features

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -76,6 +76,8 @@ const oktaAuth = new OktaAuth({
 Vue.use(OktaVue, { oktaAuth })
 ```
 
+> Note: Major version of supplied `@okta/okta-auth-js` SDK insntance should match the major version of `@okta/okta-auth-js` peerDependency of `@okta/okta-vue` SDK.
+
 ### Full `@okta/okta-auth-js` API is available
 
 `@okta/okta-vue` version 2.x and earlier provided a wrapper around [@okta/okta-auth-js][] but many methods were hidden. Version 3.x replaces `Auth` service with instance of [@okta/okta-auth-js][] for `$auth`, so the full [api](https://github.com/okta/okta-auth-js#api-reference) and all [options](https://github.com/okta/okta-auth-js#configuration-options) are now supported by this SDK. To provide a better experience, several methods which existed on the wrapper have been removed or replaced.

--- a/env.js
+++ b/env.js
@@ -4,6 +4,7 @@ const PACKAGE = require('./package.json')
 const path = require('path')
 const dotenv = require('dotenv')
 const fs = require('fs')
+const semver = require('semver')
 
 // Read environment variables from "testenv". Override environment vars if they are already set.
 const TESTENV = path.resolve(__dirname, 'testenv')
@@ -15,6 +16,9 @@ if (fs.existsSync(TESTENV)) {
   })
 }
 process.env.CLIENT_ID = process.env.CLIENT_ID || process.env.SPA_CLIENT_ID
+
+const authJsVersion = PACKAGE.peerDependencies['@okta/okta-auth-js'];
+process.env.AUTH_JS_MAJOR_VERSION = semver.minVersion(authJsVersion).major;
 
 module.exports = (overrides = {}) => {
   const PORT = overrides.port || process.env.PORT || 3000

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.29.0",
     "rollup-plugin-vue": "^6.0.0-beta.11",
+    "semver": "^7.3.5",
     "shelljs": "0.8.3",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,8 @@ const input = 'src/index.ts'
 
 const commonPlugins = [
   replace({
-    PACKAGE: JSON.stringify(ENV.packageInfo)
+    PACKAGE: JSON.stringify(ENV.packageInfo),
+    'process.env.AUTH_JS_MAJOR_VERSION': JSON.stringify(process.env.AUTH_JS_MAJOR_VERSION)
   }),
   cleanup()
 ]

--- a/src/okta-vue.ts
+++ b/src/okta-vue.ts
@@ -73,6 +73,14 @@ function install (app: App, {
     throw new AuthSdkError('No oktaAuth instance passed to OktaVue.')
   }
 
+  const oktaAuthMajorVersion = oktaAuth.userAgent?.split('/')[1]?.split('.')[0];
+  if (oktaAuthMajorVersion && oktaAuthMajorVersion !== process.env.AUTH_JS_MAJOR_VERSION) {
+    throw new AuthSdkError(`
+      Passed in oktaAuth is not compatible with the SDK,
+      okta-auth-js version ${process.env.AUTH_JS_MAJOR_VERSION}.x is the current supported version.
+    `);
+  }
+
   _oktaAuth = oktaAuth
   _onAuthRequired = onAuthRequired
 

--- a/test/specs/OktaVue.spec.js
+++ b/test/specs/OktaVue.spec.js
@@ -12,7 +12,7 @@
 
 import { mount } from '@vue/test-utils'
 import waitForExpect from 'wait-for-expect'
-import { OktaAuth } from '@okta/okta-auth-js'
+import { AuthSdkError, OktaAuth } from '@okta/okta-auth-js'
 import OktaVue from '../../src/okta-vue'
 import { App } from '../components'
 
@@ -55,6 +55,11 @@ describe('OktaVue', () => {
     oktaAuth.userAgent = 'foo'
     bootstrap()
     expect(wrapper.vm.$auth.userAgent).toBe(`${pkg.name}/${pkg.version} foo`)
+  })
+
+  it('throws when provided OktaAuth instance of unsupported version', () => {
+    oktaAuth.userAgent = 'okta-auth-js/99.0.42';
+    expect(() => bootstrap()).toThrow(AuthSdkError);
   })
 
   describe('restoreOriginalUri', () => {
@@ -115,6 +120,8 @@ describe('OktaVue', () => {
       bootstrap()
       expect(wrapper.find('#state').text()).toBe('not authenticated')
 
+      // reset modified auth-js' userAgent
+      setupOktaAuth()
       oktaAuth.authStateManager.getAuthState = jest.fn().mockReturnValue({
         isAuthenticated: true
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10262,6 +10262,13 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-vue/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Incompatible version of `@okta/okta-auth-js` can be supplied to SDK

Issue Number: N/A


## What is the new behavior?
Runtime error is thrown when incompatible `@okta/okta-auth-js` instance is provided 


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

