### PR TITLE
Fixes issue with navigationGuard by starting oktaAuth service for login redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 [authState]: https://github.com/okta/okta-auth-js#authstatemanager
 
+# 5.0.2
+
+### Bug Fixes
+
+- [77](https://github.com/okta/okta-vue/pull/77) Fix issue with `navigationGuard` by starting `oktaAuth` service for login redirect
+
+### Others
+
+- [#77](https://github.com/okta/okta-vue/pull/77) Requires @okta/okta-auth-js ^5.8.0
+
 # 5.0.1
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- [77](https://github.com/okta/okta-vue/pull/77) Fix issue with `navigationGuard` by starting `oktaAuth` service for login redirect
+- [77](https://github.com/okta/okta-vue/pull/77) Fix issue with `navigationGuard` by starting `oktaAuth` service after handling login redirect
 
 ### Others
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.12.3",
     "@babel/plugin-transform-runtime": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
-    "@okta/okta-auth-js": "^5.2.3",
+    "@okta/okta-auth-js": "^5.8.0",
     "@rollup/plugin-babel": "^5.2.1",
     "@rollup/plugin-replace": "^2.3.4",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
@@ -107,7 +107,7 @@
     "test/e2e"
   ],
   "peerDependencies": {
-    "@okta/okta-auth-js": "^5.2.3",
+    "@okta/okta-auth-js": "^5.8.0",
     "vue": "^3.0.0",
     "vue-router": "^4.0.3"
   }

--- a/src/components/LoginCallback.vue
+++ b/src/components/LoginCallback.vue
@@ -24,6 +24,7 @@ export default defineComponent({
   async beforeMount () {
     try {
       await this.$auth.handleLoginRedirect()
+      this.$auth.start();
     } catch (e) {
       if (this.$auth.isInteractionRequiredError(e)) {
         const { onAuthResume, onAuthRequired } = this.$auth.options;

--- a/src/okta-vue.ts
+++ b/src/okta-vue.ts
@@ -111,9 +111,11 @@ function install (app: App, {
     created () {
       // subscribe to the latest authState
       oktaAuth.authStateManager.subscribe(this.$_oktaVue_handleAuthStateUpdate)
-      // Calculates initial auth state and fires change event for listeners
-      // Also starts the token auto-renew service
-      oktaAuth.start();
+      if (!oktaAuth.token.isLoginRedirect()) {
+        // Calculates initial auth state and fires change event for listeners
+        // Also starts the token auto-renew service
+        oktaAuth.start();
+      }
     },
     beforeUnmount () {
       oktaAuth.authStateManager.unsubscribe(this.$_oktaVue_handleAuthStateUpdate)

--- a/src/okta-vue.ts
+++ b/src/okta-vue.ts
@@ -26,8 +26,8 @@ let _onAuthRequired: OnAuthRequiredFunction
 let _router: Router
 let originalUriTracker: string
 
-const guardSecureRoute = async (authState: AuthState) => {
-  if (!authState.isAuthenticated) {
+const guardSecureRoute = async (authState: AuthState | null) => {
+  if (authState && !authState.isAuthenticated) {
     _oktaAuth.setOriginalUri(originalUriTracker)
     if (_onAuthRequired) {
       await _onAuthRequired(_oktaAuth)
@@ -53,9 +53,7 @@ export const navigationGuard = async (to: RouteLocationNormalized) => {
     const isAuthenticated = await _oktaAuth.isAuthenticated()
     if (!isAuthenticated) {
       const authState = _oktaAuth.authStateManager.getAuthState()
-      if (authState) {
-        await guardSecureRoute(authState)
-      }
+      await guardSecureRoute(authState)
       return false
     }
 

--- a/src/okta-vue.ts
+++ b/src/okta-vue.ts
@@ -53,7 +53,9 @@ export const navigationGuard = async (to: RouteLocationNormalized) => {
     const isAuthenticated = await _oktaAuth.isAuthenticated()
     if (!isAuthenticated) {
       const authState = _oktaAuth.authStateManager.getAuthState()
-      await guardSecureRoute(authState)
+      if (authState) {
+        await guardSecureRoute(authState)
+      }
       return false
     }
 
@@ -111,11 +113,9 @@ function install (app: App, {
     created () {
       // subscribe to the latest authState
       oktaAuth.authStateManager.subscribe(this.$_oktaVue_handleAuthStateUpdate)
-      if (!oktaAuth.token.isLoginRedirect()) {
-        // Calculates initial auth state and fires change event for listeners
-        // Also starts the token auto-renew service
-        oktaAuth.start();
-      }
+      // Calculates initial auth state and fires change event for listeners
+      // Also starts the token auto-renew service
+      oktaAuth.start();
     },
     beforeUnmount () {
       oktaAuth.authStateManager.unsubscribe(this.$_oktaVue_handleAuthStateUpdate)

--- a/test/specs/LoginCallback.spec.js
+++ b/test/specs/LoginCallback.spec.js
@@ -72,8 +72,24 @@ describe('LoginCallback', () => {
     expect(oktaAuth.handleLoginRedirect).toHaveBeenCalled()
   })
 
+  it('starts oktaAuth service on login redirect', async () => {
+    createOktaAuth()
+    jest.spyOn(oktaAuth, 'handleLoginRedirect');
+    jest.spyOn(oktaAuth, 'start');
+    await navigateToCallback()
+    expect(oktaAuth.handleLoginRedirect).toHaveBeenCalled()
+    expect(oktaAuth.start).toHaveBeenCalled()
+  })
+
   it('calls the default "restoreOriginalUri" options when in login redirect uri', async () => {
     createOktaAuth()
+
+    const parseFromUrl = oktaAuth.token.parseFromUrl = jest.fn();
+    parseFromUrl._getLocation = jest.fn().mockReturnValue({
+      hash: '#mock-hash',
+      search: '?mock-search'
+    });
+    
     await navigateToCallback({ isLoginRedirect: true })
     jest.spyOn(oktaAuth.options, 'restoreOriginalUri')
     // nextTick only wait on dom updates, explicitly wait for the next event loop happen as no dom update here

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,13 +1211,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@okta/okta-auth-js@^5.2.3":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-5.2.3.tgz#ab6334fdde3236b833d9cd50da33570f114b0667"
-  integrity sha512-I6xcZO4mzNUsQSmZF+m8IojuXr5dxghHUIbpiGjbZLQfUpvaxUGAuxJoXecnsXITnp4/WnvyUxbKWeRLSAIRGQ==
+"@okta/okta-auth-js@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-5.8.0.tgz#e80a550e7850f3bc89ea3d6bcd6a66a95f8702f5"
+  integrity sha512-gkQ3/IOlG10FsE7h3GCN38BJGv7QZqr8clh5dpmjmZ4L1xtFwoDuk1VP0iaHtxr3UhsOG/wxNx17tnFAuSjeoQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@okta/okta-idx-js" "0.18.0"
+    "@okta/okta-idx-js" "0.22.0"
     "@peculiar/webcrypto" "1.1.6"
     Base64 "1.1.0"
     atob "^2.1.2"
@@ -1232,10 +1232,10 @@
     webcrypto-shim "^0.1.5"
     xhr2 "0.1.3"
 
-"@okta/okta-idx-js@0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.18.0.tgz#a419c915a68bcb925da33fe57a651826f681c57a"
-  integrity sha512-r6MZ7SMY/KwKVxDv0CuBR5QS5Iy6NsZCEC/zHqNpgXCd0GcKJPqrAt/xDWkp9oUccZrXI4PauU6zHnFSHLJEag==
+"@okta/okta-idx-js@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.22.0.tgz#c5dbebd155be2c8a8e2bbceb2e92701b6ba59349"
+  integrity sha512-SehJVwQI51xWrB1YaMn6UB54cOzhrM7z5k2xOI62I3B7qOQ3uFOZJvRCJnBcZ6TEcQuqJ3/6q93h6n8omw0tVQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-vue/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
After expiring of tokens when user tries to navigate to protected page, `navigationGuard` will be called. 
`_oktaAuth.isAuthenticated()` will return false, but `_oktaAuth.authStateManager.getAuthState()` will contain `isAuthenticated: true`, so `guardSecureRoute` will do nothing.

Issue Number: OKTA-420066
Resolves #72 


## What is the new behavior?
Need to start oktaAuth service after `handleLoginRedirect()` call in `LoginCallback` component. This way `isAuthenticated` will be correct.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Using okta-auth-js 5.4.3+ will fix issue (see [comment](https://github.com/okta/okta-vue/issues/72#issuecomment-899705911)) because of using default `autoRenew: true` in `isAuthenticated()` call which will remove expired tokens.

Updated `okta-auth-js` to `^5.8.0`

## Reviewers

