### PR TITLE
Add composable function `useAuth` for setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,35 @@ export default defineComponent({
 </script>
 ```
 
+If you are using setup function or setup script, you can access the oktaAuth instance with `useAuth` composable.
+
+```typescript
+// src/App.vue
+
+<template>
+  <div id="app">
+    <router-link to="/" tag="button" id='home-button'> Home </router-link>
+    <button v-if='authState && authState.isAuthenticated' v-on:click='logout' id='logout-button'> Logout </button>
+    <button v-else v-on:click='login' id='login-button'> Login </button>
+    <router-view/>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useAuth } from '@okta/okta-vue';
+
+const auth = useAuth();
+
+const login = async () => {
+  await auth.signInWithRedirect()
+}
+
+const logout = async () => {
+  await auth.signOut()
+}
+</script>
+```
+
 ### Use the Access Token
 
 When your users are authenticated, your Vue application has an access token that was issued by your Okta Authorization server. You can use this token to authenticate requests for resources on your server or API. As a hypothetical example, let's say you have an API that provides messages for a user. You could create a `MessageList` component that gets the access token and uses it to make an authenticated request to your server.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 
-import OktaVue, { navigationGuard } from './okta-vue'
+import OktaVue, { navigationGuard, useAuth } from './okta-vue'
 import LoginCallback from './components/LoginCallback.vue'
 
 export default OktaVue
-export { LoginCallback, navigationGuard }
+export { LoginCallback, navigationGuard, useAuth }
 export * from './types'

--- a/src/okta-vue.ts
+++ b/src/okta-vue.ts
@@ -150,4 +150,12 @@ function install (app: App, {
   app.config.globalProperties.$auth = oktaAuth
 }
 
+export function useAuth() {
+  if (!_oktaAuth) {
+    throw new AuthSdkError('No oktaAuth instance has instantiated.')
+  }
+
+  return _oktaAuth
+}
+
 export default { install }

--- a/test/specs/OktaVue.interface.spec.js
+++ b/test/specs/OktaVue.interface.spec.js
@@ -12,7 +12,7 @@
 
 import { mount } from '@vue/test-utils'
 import { OktaAuth } from '@okta/okta-auth-js'
-import OktaVue, { LoginCallback, navigationGuard } from '../../src'
+import OktaVue, { LoginCallback, navigationGuard, useAuth } from '../../src'
 import InternalLoginCallback from '../../src/components/LoginCallback'
 import { navigationGuard as internalNavigationGuard } from '../../src/okta-vue'
 
@@ -39,6 +39,8 @@ describe('OktaVue module', () => {
       }
     })
     expect(wrapper.vm.$auth instanceof OktaAuth).toBeTruthy()
+    const auth = useAuth()
+    expect(wrapper.vm.$auth).toBe(auth)
   })
   test('exports "LoginCallback" component', () => {
     expect(LoginCallback).toBe(InternalLoginCallback)


### PR DESCRIPTION
- Adds composable `useAuth()` to access the oktaAuth instance in setup script
- Added unit test

Copy of https://github.com/okta/okta-vue/pull/102
Resolves #101 
Internal ref: https://oktainc.atlassian.net/browse/OKTA-516507