### PR TITLE
Use siw-platform-scripts instead of artifactory url

### DIFF
--- a/scripts/e2e-v6.sh
+++ b/scripts/e2e-v6.sh
@@ -17,7 +17,7 @@ export CI=true
 export ISSUER=https://samples-javascript.okta.com/oauth2/default
 export SPA_CLIENT_ID=0oapmwm72082GXal14x6
 export USERNAME=george@acme.com
-get_secret prod/okta-sdk-vars/password PASSWORD
+get_vault_secret_key devex/samples-javascript password PASSWORD
 
 if ! yarn add -DW --ignore-scripts @okta/okta-auth-js@^6; then
   echo "auth-js v6.x could not be installed"

--- a/scripts/e2e-v6.sh
+++ b/scripts/e2e-v6.sh
@@ -2,6 +2,11 @@
 
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 
+if [ ! -z "$AUTHJS_VERSION" ]; then
+  echo "Skipping e2e tests against auth-js v6.x"
+  exit ${SUCCESS}
+fi
+
 setup_service java 1.8.222
 setup_service google-chrome-stable 106.0.5249.61-1
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -12,7 +12,7 @@ export CI=true
 export ISSUER=https://samples-javascript.okta.com/oauth2/default
 export SPA_CLIENT_ID=0oapmwm72082GXal14x6
 export USERNAME=george@acme.com
-get_secret prod/okta-sdk-vars/password PASSWORD
+get_vault_secret_key devex/samples-javascript password PASSWORD
 
 if ! yarn test:e2e; then
   echo "e2e tests failed! Exiting..."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,45 +1,40 @@
 #!/bin/bash -xe
 
+DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+source $DIR/utils/local.sh
+source $DIR/utils/siw-platform-scripts.sh
+
 # Can be used to run a canary build against a beta AuthJS version that has been published to artifactory.
 # This is available from the "downstream artifact" menu on any okta-auth-js build in Bacon.
 # DO NOT MERGE ANY CHANGES TO THIS LINE!!
 export AUTHJS_VERSION=""
 
-# Add yarn to the $PATH so npm cli commands do not fail
-export PATH="${PATH}:$(yarn global bin)"
-
 # Install required node version
 export NVM_DIR="/root/.nvm"
 setup_service node v14.19.3
 
+# Install yarn
+# Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
+setup_service yarn 1.21.1 /etc/pki/tls/certs/ca-bundle.crt
+
+# Add yarn to the $PATH so npm cli commands do not fail
+export PATH="${PATH}:$(yarn global bin)"
+
 cd ${OKTA_HOME}/${REPO}
 
-# undo permissions change on scripts/publish.sh
-git checkout -- scripts
+# if running on bacon
+if [ -n "${TEST_SUITE_ID}" ]; then
+  # undo permissions change on scripts/publish.sh
+  git checkout -- scripts
 
-# ensure we're in a branch on the correct sha
-git checkout $BRANCH
-git reset --hard $SHA
+  # ensure we're in a branch on the correct sha
+  git checkout $BRANCH
+  git reset --hard $SHA
 
-git config --global user.email "oktauploader@okta.com"
-git config --global user.name "oktauploader-okta"
+  git config --global user.email "oktauploader@okta.com"
+  git config --global user.name "oktauploader-okta"
+fi
 
-#!/bin/bash
-YARN_REGISTRY=https://registry.yarnpkg.com
-OKTA_REGISTRY=${ARTIFACTORY_URL}/api/npm/npm-okta-master
-
-# Yarn does not utilize the npmrc/yarnrc registry configuration
-# if a lockfile is present. This results in `yarn install` problems
-# for private registries. Until yarn@2.0.0 is released, this is our current
-# workaround.
-#
-# Related issues:
-#  - https://github.com/yarnpkg/yarn/issues/5892
-#  - https://github.com/yarnpkg/yarn/issues/3330
-
-# Replace yarn registry with Okta's
-echo "Replacing $YARN_REGISTRY with $OKTA_REGISTRY within yarn.lock files..."
-sed -i "s#${YARN_REGISTRY}#${OKTA_REGISTRY}#" yarn.lock
 
 # Install dependencies but do not build
 if ! yarn install --frozen-lockfile --ignore-scripts; then
@@ -47,25 +42,14 @@ if ! yarn install --frozen-lockfile --ignore-scripts; then
   exit ${FAILED_SETUP}
 fi
 
-# Revert the original change(s)
-echo "Replacing $OKTA_REGISTRY with $YARN_REGISTRY within yarn.lock files..."
-sed -i "s#${OKTA_REGISTRY}#${YARN_REGISTRY}#" yarn.lock
 
 # Install a specific version of auth-js, used by downstream artifact builds
 if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
-  npm config set strict-ssl false
-
-  AUTHJS_URI=https://artifacts.aue1d.saasure.com/artifactory/npm-topic/@okta/okta-auth-js/-/@okta/okta-auth-js-${AUTHJS_VERSION}.tgz
-  if ! yarn add -DW --ignore-scripts ${AUTHJS_URI}; then
-    echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"
-    exit ${FAILED_SETUP}
-  fi
-
+  install_siw_platform_scripts
+  install_artifact @okta/okta-auth-js "${AUTHJS_VERSION}"
   # NOTE: no additional auth-js versions are included in this repo. If this changes ensure the downstream auth-js is used in all test envs/apps
   # Example here: https://github.com/okta/okta-react/blob/58883b02f95aeb21befe61ae60e11e4591c792d6/scripts/setup.sh#L69
-
-  npm config set strict-ssl true
   echo "AUTHJS_VERSION installed: ${AUTHJS_VERSION}"
 
   # verify single version of auth-js is installed

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -57,24 +57,7 @@ if [ ! -z "$AUTHJS_VERSION" ]; then
   AUTHJS_INSTALLS=$(find . -type d -path "*/node_modules/@okta/okta-auth-js" -not -path "*/okta-signin-widget/*" | wc -l)
   if [ $AUTHJS_INSTALLS -gt 1 ]
   then
-    echo "ADDITIONAL AUTH JS INSTALL DETECTED (check 1)"
-    yarn why @okta/okta-auth-js
-    exit ${FAILED_SETUP}
-  fi
-
-  # parses `yarn why` output to generate an json array of installed versions
-  INSTALLED_VERSIONS=$(yarn why --json @okta/okta-auth-js | jq -r -s 'map(select(.type == "info") | select(.data | strings | contains("Found"))) | map(.data[11:-1] | select(contains("okta-signin-widget") | not)) | map(split("@")[-1]) | unique')
-
-  if [ $(echo $INSTALLED_VERSIONS | jq length) -ne 1 ]
-  then
-    echo "ADDITIONAL AUTH JS INSTALL DETECTED (check 2)"
-    yarn why @okta/okta-auth-js
-    exit ${FAILED_SETUP}
-  fi
-
-  if [ $(echo $INSTALLED_VERSIONS | jq .[0] | tr -d \" ) != $AUTHJS_VERSION ]
-  then
-    echo "ADDITIONAL AUTH JS INSTALL DETECTED (check 3)"
+    echo "ADDITIONAL AUTH JS INSTALL DETECTED"
     yarn why @okta/okta-auth-js
     exit ${FAILED_SETUP}
   fi

--- a/scripts/unit-v6.sh
+++ b/scripts/unit-v6.sh
@@ -2,6 +2,11 @@
 
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 
+if [ ! -z "$AUTHJS_VERSION" ]; then
+  echo "Skipping unit tests against auth-js v6.x"
+  exit ${SUCCESS}
+fi
+
 export TEST_SUITE_TYPE="junit"
 export TEST_RESULT_FILE_DIR="${REPO}/test-reports/unit"
 

--- a/scripts/utils/local.sh
+++ b/scripts/utils/local.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# if not running on bacon
+if [ -z "${TEST_SUITE_ID}" ]; then
+  export OKTA_HOME=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/../.." &> /dev/null && pwd)
+  export REPO="."
+  export TEST_SUITE_TYPE_FILE=/dev/null
+  export TEST_RESULT_FILE_DIR_FILE=/dev/null
+
+  ### (known) Bacon exit codes
+  # success
+  export SUCCESS=0
+  export PUBLISH_TYPE_AND_RESULT_DIR=0
+  export PUBLISH_TYPE_AND_RESULT_DIR_BUT_SUCCEED_IF_NO_RESULTS=0
+  # failure
+  export FAILURE=1
+  export FAILED_SETUP=1
+  export TEST_FAILURE=1
+  export PUBLISH_TYPE_AND_RESULT_DIR_BUT_ALWAYS_FAIL=1
+  export PUBLISH_ARTIFACTORY_FAILURE=1
+
+  # bacon commands
+  setup_service () {
+    echo 'noop'
+  }
+
+  get_secret () {
+    # ensures the env var is set
+    key="$2"
+    if [ -z "${!key}" ]; then
+      echo "$key is not defined. Exiting..."
+      exit 1
+    fi
+  }
+
+  get_vault_secret_key () {
+    # ensures the env var is set
+    key="$3"
+    if [ -z "${!key}" ]; then
+      echo "$key is not defined. Exiting..."
+      exit 1
+    fi
+  }
+
+  set -x  # when running locally, might as well see all the commands being ran
+fi

--- a/scripts/utils/siw-platform-scripts.sh
+++ b/scripts/utils/siw-platform-scripts.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# if running on bacon
+if [ -n "${TEST_SUITE_ID}" ]; then
+  export SIW_PLATFORM_ENV="bacon"
+else
+  export SIW_PLATFORM_ENV="local"
+fi
+
+orig_ssl=$(yarn config get strict-ssl)
+orig_registry=$(yarn config get @okta:registry)
+REGISTRY="${ARTIFACTORY_URL}/api/npm/npm-topic"
+
+update_yarn_config () {
+  if [ "$SIW_PLATFORM_ENV" == "local" ] ; then
+    yarn config set @okta:registry ${REGISTRY}
+    yarn config set strict-ssl false
+    trap restore_yarn_config EXIT
+  fi
+}
+
+restore_yarn_config () {
+  if [ "$SIW_PLATFORM_ENV" == "local" ] ; then
+    if [ "$orig_registry" == "undefined" ] ; then
+      yarn config delete @okta:registry
+    else
+      yarn config set @okta:registry $orig_registry
+    fi
+    yarn config set strict-ssl $orig_ssl
+  fi
+}
+
+install_siw_platform_scripts () {
+  update_yarn_config
+  if ! yarn global add @okta/siw-platform-scripts ; then
+    echo "siw-platform-scripts could not be installed"
+    exit ${FAILED_SETUP}
+  fi
+  restore_yarn_config
+}
+
+install_artifact () {
+  # $1 = package name
+  # $2 = version
+  update_yarn_config
+  if ! siw-platform install-artifact -e ${SIW_PLATFORM_ENV} -n $1 -v $2 ; then
+    echo "$1 $2 could not be installed via siw-platform"
+    exit ${FAILED_SETUP}
+  fi
+  restore_yarn_config
+}


### PR DESCRIPTION
- Use `siw-platform-scripts` to install auth-js instead of internal artifactory url
- Added support of local running e2e and setup scripts


Internal ref: [OKTA-607424](https://oktainc.atlassian.net/browse/OKTA-607424)
