### PR TITLE
Support Composition API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 5.7.0
+
+### Features
+
+- [#139](https://github.com/okta/okta-vue/pull/139)
+  - Plugin supports both Options API and Composition API
+  - `LoginCallback` component and test app migrated to Composition API
+
+### Fixes
+
+- [#139](https://github.com/okta/okta-vue/pull/139) Fixes `TypeError: 'set' on proxy: trap returned falsish for property 'authState'` when plugin is used in app with Composition API
+
 # 5.6.0
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -157,8 +157,9 @@ If a user does not have a valid session, then a new authorization flow will begi
 
 ### Show Login and Logout Buttons
 
-In the relevant location in your application, you will want to provide `Login` and `Logout` buttons for the user. You can show/hide the correct button by using the injected reactive [authState][] property. For example:
+In the relevant location in your application, you will want to provide `Login` and `Logout` buttons for the user. You can show/hide the correct button by using the injected reactive [authState][] property. 
 
+Example for Options API:
 ```typescript
 // src/App.vue
 
@@ -188,8 +189,7 @@ export default defineComponent({
 </script>
 ```
 
-If you are using setup function or setup script, you can access the oktaAuth instance with `useAuth` composable.
-
+If you are using Composition API, you can access the OktaAuth instance with `useAuth()` composable.
 ```typescript
 // src/App.vue
 
@@ -205,7 +205,7 @@ If you are using setup function or setup script, you can access the oktaAuth ins
 <script setup lang="ts">
 import { useAuth } from '@okta/okta-vue';
 
-const auth = useAuth();
+const $auth = useAuth();
 
 const login = async () => {
   await auth.signInWithRedirect()
@@ -214,6 +214,16 @@ const login = async () => {
 const logout = async () => {
   await auth.signOut()
 }
+</script>
+```
+
+If you have disabled Options API (use [`__VUE_OPTIONS_API__: false`](https://github.com/vuejs/core/blob/main/packages/vue/README.md#bundler-build-feature-flags)), you need to inject `okta.authState` and expose property named `authState` in setup in order to use `authState` in template:
+
+```typescript
+<script setup lang="ts">
+import { ShallowRef, inject } from 'vue';
+import { AuthState } from '@okta/okta-auth-js';
+const authState = inject<ShallowRef<AuthState>>('okta.authState')
 </script>
 ```
 
@@ -310,7 +320,26 @@ Note that `onAuthResume` has the same signature as `onAuthRequired`. If you do n
 
 ### `$auth`
 
-This SDK works as a [Vue Plugin][]. It provides an instance of the [Okta Auth SDK][] to your components on the [globalProperties][]. You can access the [Okta Auth SDK][] instance by using `this.$auth` in your components.
+This SDK works as a [Vue Plugin][]. It provides an instance of the [Okta Auth SDK][] to your components on the [globalProperties][]. For Options API you can access the [Okta Auth SDK][] instance by using `this.$auth` in your components. For Composition API you can access the OktaAuth instance with `useAuth()` composable.
+
+```typescript
+import { useAuth } from '@okta/okta-vue';
+const $auth = useAuth();
+```
+
+### `authState`
+
+This SDK provides reactive [authState][] property for your components. For Options API you can access the value by using `this.authState` in your components. For Composition API you can inject `okta.authState`:
+
+```typescript
+import { inject, ShallowRef } from 'vue';
+import { AuthState } from '@okta/okta-auth-js';
+const authState = inject<ShallowRef<AuthState>>('okta.authState');
+// use authState.value
+```
+
+Note that if you have disabled Options API (with [`__VUE_OPTIONS_API__: false`](https://github.com/vuejs/core/blob/main/packages/vue/README.md#bundler-build-feature-flags)), you need to expose property `authState` in setup in order to use `authState` in template.
+
 
 ### `LoginCallback`
 

--- a/src/okta-vue.ts
+++ b/src/okta-vue.ts
@@ -121,7 +121,7 @@ function install (app: App, {
   oktaAuth.authStateManager.subscribe(handleAuthStateUpdate)
 
   // Use mixin to support Options API
-  if (__VUE_OPTIONS_API__ !== false) {
+  if (typeof __VUE_OPTIONS_API__ === 'undefined' || __VUE_OPTIONS_API__ === true) {
     app.mixin({
       computed: {
         authState() {

--- a/src/okta-vue.ts
+++ b/src/okta-vue.ts
@@ -131,10 +131,6 @@ function install (app: App, {
     })
   }
   // Provide ref to authState to support Composition API
-  if (compare(version, '3.3', '<')) {
-    // Should be unwrapped in all 3.x versions
-    app.config.unwrapInjectedRef = true
-  }
   app.provide('okta.authState', authStateRef)
 
   // add additional options to oktaAuth options

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,10 +8,21 @@ export interface OktaVueOptions {
   onAuthResume?: OnAuthRequiredFunction;
 }
 
+export type OktaAuthVue = OktaAuth & {
+  isInteractionRequiredError?: (error: Error) => boolean;
+  options: {
+    onAuthRequired?: OnAuthRequiredFunction;
+    onAuthResume?: OnAuthRequiredFunction;
+  };
+}
+
 declare module '@vue/runtime-core' {
   interface ComponentCustomProperties {
-    $auth: OktaAuth;
+    $auth: OktaAuthVue;
     authState: AuthState;
-    $_oktaVue_handleAuthStateUpdate: (authState: AuthState) => void;
   }
+}
+
+declare global {
+  const __VUE_OPTIONS_API__: boolean;
 }

--- a/test/apps/test-harness/src/App.vue
+++ b/test/apps/test-harness/src/App.vue
@@ -3,6 +3,7 @@
     <router-link to="/" tag="button" id='home-button'> Home </router-link>
     <button v-if='authState && authState.isAuthenticated' v-on:click='logout' id='logout-button'> Logout </button>
     <button v-else v-on:click='login' id='login-button'> Login </button>
+    <router-link v-if='!authState || !authState.isAuthenticated' to="/sessionToken" tag="button" id='session-login-button'> Session login </router-link>
     <router-link id="protected-link" to="/protected" tag="button"> Protected </router-link>
     <router-view v-slot="{ Component }">
       <component :is="Component">
@@ -14,18 +15,32 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
 
-export default defineComponent({
-  name: 'app',
-  methods: {
-    login () {
-      this.$auth.signInWithRedirect()
-    },
-    async logout () {
-      await this.$auth.signOut()
+<script lang="ts">
+import { useAuth } from '@okta/okta-vue';
+import { ShallowRef, inject } from 'vue';
+import { AuthState } from '@okta/okta-auth-js';
+
+export default {
+  setup() {
+    const authState = inject<ShallowRef<AuthState>>('okta.authState')
+    const $auth = useAuth()
+
+    const login = () => {
+      $auth.signInWithRedirect()
+    };
+
+    const logout = async () => {
+      $auth.signOut();
+    };
+
+    return {
+      logout,
+      login,
+      // required if you've disabled Options API with `__VUE_OPTIONS_API__: false`
+      authState,
     }
   }
-})
+}
 </script>
+

--- a/test/apps/test-harness/src/components/Home.vue
+++ b/test/apps/test-harness/src/components/Home.vue
@@ -2,11 +2,3 @@
   <div class="home">
   </div>
 </template>
-  
-<script lang="ts">
-import { defineComponent } from 'vue'
-
-export default defineComponent({
-  name: 'Home'
-})
-</script>

--- a/test/apps/test-harness/src/components/Protected.vue
+++ b/test/apps/test-harness/src/components/Protected.vue
@@ -1,29 +1,61 @@
 <template>
   <div class="protected">
-    {{ message }}
-    <pre id="userinfo-container" class="userinfo">{{ user }}</pre>
+    <div v-if="authState && authState.isAuthenticated">
+      {{ message }}
+      <br />
+      <button v-if='authState && authState.isAuthenticated' v-on:click='renewToken' id='upd-button'>Renew token</button>
+      <br />
+      <br />
+      <div>User:</div>
+      <pre id="userinfo-container" class="userinfo">{{ user }}</pre>
+      <br />
+      <div>Access token claims:</div>
+      <pre id="token-claims-container" class="tokenclaims">{{ tokenClaims }}</pre>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { inject, ShallowRef, ref, onMounted } from 'vue';
+import { AuthState } from '@okta/okta-auth-js';
+import { useAuth } from '@okta/okta-vue';
 
-export default defineComponent({
-  name: 'Protected',
-  data () {
-    return {
-      message: 'Protected!',
-      user: ''
+export default {
+  setup() {
+    const authState = inject<ShallowRef<AuthState>>('okta.authState')
+    const $auth = useAuth()
+    const message = ref('Protected!')
+    const user = ref('')
+    const tokenClaims = ref('')
+
+    const getUser = async () => {
+      const userJson = await $auth.getUser()
+      user.value = JSON.stringify(userJson, null, 4)
     }
-  },
-  created () {
-    this.getUser()
-  },
-  methods: {
-    async getUser () {
-      const user = await this.$auth.getUser()
-      this.user = JSON.stringify(user, null, 4)
+
+    const updateTokenClaims = () => {
+      const accessTokenClaims = $auth.tokenManager.getTokensSync().accessToken?.claims;
+      tokenClaims.value = JSON.stringify(accessTokenClaims, null, 4)
+    }
+
+    const renewToken = async () => {
+      await $auth.tokenManager.renew('accessToken');
+    }
+
+    onMounted(() => {
+      updateTokenClaims()
+      $auth.authStateManager.subscribe(updateTokenClaims)
+      getUser()
+    })
+
+    return {
+      message,
+      user,
+      tokenClaims,
+      renewToken,
+      // required if you've disabled Options API with `__VUE_OPTIONS_API__: false`
+      authState,
     }
   }
-})
+}
 </script>

--- a/test/apps/test-harness/src/components/Protected.vue
+++ b/test/apps/test-harness/src/components/Protected.vue
@@ -10,7 +10,7 @@
       <pre id="userinfo-container" class="userinfo">{{ user }}</pre>
       <br />
       <div>Access token claims:</div>
-      <pre id="token-claims-container" class="tokenclaims">{{ tokenClaims }}</pre>
+      <pre id="token-claims-container" class="tokenclaims">{{ authState.accessToken?.claims }}</pre>
     </div>
   </div>
 </template>
@@ -26,16 +26,10 @@ export default {
     const $auth = useAuth()
     const message = ref('Protected!')
     const user = ref('')
-    const tokenClaims = ref('')
 
     const getUser = async () => {
       const userJson = await $auth.getUser()
       user.value = JSON.stringify(userJson, null, 4)
-    }
-
-    const updateTokenClaims = () => {
-      const accessTokenClaims = $auth.tokenManager.getTokensSync().accessToken?.claims;
-      tokenClaims.value = JSON.stringify(accessTokenClaims, null, 4)
     }
 
     const renewToken = async () => {
@@ -43,15 +37,12 @@ export default {
     }
 
     onMounted(() => {
-      updateTokenClaims()
-      $auth.authStateManager.subscribe(updateTokenClaims)
       getUser()
     })
 
     return {
       message,
       user,
-      tokenClaims,
       renewToken,
       // required if you've disabled Options API with `__VUE_OPTIONS_API__: false`
       authState,

--- a/test/apps/test-harness/src/components/SessionTokenLogin.vue
+++ b/test/apps/test-harness/src/components/SessionTokenLogin.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sessionTokenLogin">
+  <div class="sessionTokenLogin" v-if="!authState || !authState.isAuthenticated">
     <br/>
     <label>
       Username:
@@ -7,30 +7,52 @@
       Password:
       <input id="password" type="password" v-model="password"/>
     </label>
-    <button id="submit" v-on:click="signIn">Login</button>
+    <button id="submit" @click="signIn">Login</button>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { inject, ShallowRef, ref } from 'vue';
+import { AuthState } from '@okta/okta-auth-js';
+import { useAuth } from '@okta/okta-vue'
 
-export default defineComponent({
-  name: 'SessionTokenLogin',
-  data () {
-    return { username: '', password: '' }
+export default {
+  props: {
+    withRedirect: Boolean
   },
-  methods: {
-    signIn () {
-      this.$auth.signInWithCredentials({
-        username: this.username,
-        password: this.password
+  setup({ withRedirect }) {
+    const authState = inject<ShallowRef<AuthState>>('okta.authState')
+    const $auth = useAuth()
+    const username = ref('')
+    const password = ref('')
+
+    const signIn = () => {
+      $auth.signInWithCredentials({
+        username: username.value,
+        password: password.value,
       })
-      .then(res => {
-        this.$auth.setOriginalUri('/protected');
-        return this.$auth.token.getWithRedirect({sessionToken: res.sessionToken});
+      .then(async (res) => {
+        if (withRedirect) {
+          // Demonstrates redirect to /protected
+          $auth.setOriginalUri('/protected');
+          return $auth.token.getWithRedirect({sessionToken: res.sessionToken});
+        } else {
+          // Demostrates reactiveness of authState
+          const { tokens } = await $auth.token.getWithoutPrompt({ sessionToken: res.sessionToken });
+          $auth.tokenManager.setTokens(tokens);
+        }
       })
       .catch(err => console.error(`Found an error: ${err}`))
     }
-  }
-})
+
+    return {
+      username,
+      password,
+      signIn,
+      // required if you've disabled Options API with `__VUE_OPTIONS_API__: false`
+      authState,
+    }
+  },
+}
+
 </script>

--- a/test/apps/test-harness/src/router/index.ts
+++ b/test/apps/test-harness/src/router/index.ts
@@ -10,7 +10,7 @@ const router = createRouter({
     { path: '/', component: Home },
     { path: '/login/callback', component: LoginCallback },
     { path: '/protected', component: Protected, meta: { requiresAuth: true } },
-    { path: '/sessionToken', component: SessionTokenLogin }
+    { path: '/sessionToken', component: SessionTokenLogin, props: { withRedirect: true } }
   ]
 })
 

--- a/test/apps/test-harness/vite.config.js
+++ b/test/apps/test-harness/vite.config.js
@@ -35,6 +35,7 @@ export default defineConfig({
   define: {
     'process.env': env,
     'CONFIG': env,
+    '__VUE_OPTIONS_API__': false
   },
   resolve: {
     alias: [

--- a/test/specs/LoginCallback.spec.js
+++ b/test/specs/LoginCallback.spec.js
@@ -64,9 +64,7 @@ describe('LoginCallback', () => {
 
   it('renders the component', async () => {
     createOktaAuth()
-    jest.spyOn(LoginCallback, 'render')
     await navigateToCallback()
-    expect(LoginCallback.render).toHaveBeenCalled()
     expect(wrapper.text()).toBe('')
   })
 

--- a/test/specs/OktaVue.spec.js
+++ b/test/specs/OktaVue.spec.js
@@ -13,6 +13,7 @@
 import { mount } from '@vue/test-utils'
 import waitForExpect from 'wait-for-expect'
 import { AuthSdkError, OktaAuth } from '@okta/okta-auth-js'
+import { createRouter, createWebHistory } from 'vue-router'
 import OktaVue from '../../src/okta-vue'
 import { App } from '../components'
 
@@ -33,17 +34,18 @@ describe('OktaVue', () => {
   }
 
   function bootstrap (options = {}) {
-    mockRouter = {
-      replace: jest.fn()
-    }
+    mockRouter = createRouter({
+      history: createWebHistory(),
+      routes: [
+      ]
+    })
+    mockRouter.replace = jest.fn()
     wrapper = mount(App, {
       global: {
         plugins: [
-          [OktaVue, { oktaAuth, ...options }]
+          [OktaVue, { oktaAuth, ...options }],
+          mockRouter,
         ],
-        mocks: {
-          $router: mockRouter
-        }
       }
     })
   }
@@ -151,13 +153,6 @@ describe('OktaVue', () => {
       bootstrap()
       expect(wrapper.find('#state').text()).toBe('authenticated')
     })
-  })
-
-  it('should unsubscribe authState change when before component destroy', () => {
-    oktaAuth.authStateManager.unsubscribe = jest.fn()
-    bootstrap()
-    wrapper.unmount()
-    expect(oktaAuth.authStateManager.unsubscribe).toHaveBeenCalledWith(wrapper.vm.$_oktaVue_handleAuthStateUpdate)
   })
 
   it('should call service start, but not stop', () => {


### PR DESCRIPTION
Resolves #128 , #129

Internal ref: [OKTA-645251](https://oktainc.atlassian.net/browse/OKTA-645251)

PR to update samples: https://github.com/okta/samples-js-vue/pull/160

Chnages:
- `okta-vue` plugin supports both Options API (via mixin that exposes only computable `authState`) and Composition API (by providing new injectable with name `okta.authState`). If flag `__VUE_OPTIONS_API__` is false, user should inject `okta.authState` and return `authState` property from `setup`.
- New mixin code is more efficient. Previously every component was subscribing (and unsubscribing on destroy) to auth state update, now there is one global subscriber. Using `shallowRef` and `triggerRef` is also more sufficient and error-prone (fixes #129)
- `LoginCallback` component migrated to Composition API
- Test app migrated to Composition API
- Updated Protected page in test app - show access token claims and button to renew token (to demonstrate reactivity of `authState `)
