### PR TITLE
docs[okta-vue]: fix misspelled reference in composition api example

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ If you are using Composition API, you can access the OktaAuth instance with `use
 <script setup lang="ts">
 import { useAuth } from '@okta/okta-vue';
 
-const $auth = useAuth();
+const auth = useAuth();
 
 const login = async () => {
   await auth.signInWithRedirect()


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-vue/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
In the example for showing Login and Logout buttons in the documentation, the composition API example mistakenly references `auth` as `$auth`:

```
<script setup lang="ts">
import { useAuth } from '@okta/okta-vue';

const $auth = useAuth();

const login = async () => {
  await auth.signInWithRedirect()
}

const logout = async () => {
  await auth.signOut()
}
</script>
```

References prefixed with a `$` is typically used to depict properties that are globally available in the application, as stated in Vue 2 documentation:

> $ is a convention Vue uses for properties that are available to all instances [[source: Instance Properties in Vue](https://v2.vuejs.org/v2/cookbook/adding-instance-properties.html?redirect=true#The-Importance-of-Scoping-Instance-Properties)]

The variable `auth` is also undefined in the example as the composable is set to the variable `$auth`. 

## What is the new behavior?

Change the reference from `$auth` to `auth` so that the reference is accurate and compliant with Vue conventions. 


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

