### PR TITLE
fix[okta-vue]: Updates vue global type augmentation

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,7 @@ export type OktaAuthVue = OktaAuth & {
   };
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $auth: OktaAuthVue;
     authState: AuthState;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-vue/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [x] Other... Please describe: Type declaration necessary update


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, component custom properties are declared following the old vue guidelines (by declaring them in the `@vue/runtime-core` module)
This is working fine as long as all other dependencies of a repository still rely on `declare module '@vue/runtime-core'` 

The current expected way of declaring component custom properties is by using the syntax `declare module 'vue'` ([official documentation](https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties)).

Using both syntaxes in a same repository leads to an override of all properties declared via `declare module 'vue'`
This implies that using the current version of this package causes type issues when using other up to date packages.

Issue Number: #144 


## What is the new behavior?

Global component custom properties are now declared using the new syntax, which makes this package's type definitions compatible with other up to date packages.


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

If used with other out of date packages, typescript will consider `$auth` and `authState` to be undefined (until out of date dependencies are all updated to rely on the `declare module 'vue'` syntax) 

## Other information


## Reviewers

