### PR TITLE
fix: Update global properties type declaraton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.8.0
+
+### Fixes
+[#150](https://github.com/okta/okta-vue/pull/150) Updates global properties type declaraton
+  - resolves [#149](https://github.com/okta/okta-vue/pull/149)
+
 # 5.7.0
 
 ### Features

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,7 @@ export type OktaAuthVue = OktaAuth & {
   };
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $auth: OktaAuthVue;
     authState: AuthState;


### PR DESCRIPTION
Augmenting global properties in vue must now be done via the module 'vue' instead of '@vue/runtime-core'

Resolves: #144

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-vue/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

